### PR TITLE
Refactor imports to use cupertino_ui and material_ui packages consist…

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/cupertino.dart' show CupertinoColors, CupertinoIcons;
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart' show CupertinoColors, CupertinoIcons;
+import 'package:material_ui/material_ui.dart';
 import 'package:native_adaptive_ui/native_adaptive_ui.dart';
 
 Future<void> main() async {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
   native_adaptive_ui:
     path: ../
 
+  cupertino_ui: any
+  material_ui: any
 dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:native_adaptive_ui/native_adaptive_ui.dart';
 

--- a/lib/src/design_systems/design_imports.dart
+++ b/lib/src/design_systems/design_imports.dart
@@ -22,5 +22,5 @@
 /// the only place they need to be resolved.
 library;
 
-export 'package:flutter/cupertino.dart' hide RefreshCallback;
-export 'package:flutter/material.dart';
+export 'package:cupertino_ui/cupertino_ui.dart' hide RefreshCallback;
+export 'package:material_ui/material_ui.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,19 +44,19 @@ dependencies:
   # draw from it, and without the dependency every one of those glyphs renders
   # as a "?" box in the consuming app.
   cupertino_icons: ^1.0.8
+  cupertino_ui: ^1.0.1
   flutter:
     sdk: flutter
   # Rasterizes AdaptiveDestination.iconSvgAsset for the native UITabBar — Flutter's
   # own image pipeline has no SVG decoder, and a native UIImage needs raster bytes.
   flutter_svg: ^2.2.1
+  material_ui: ^1.1.0
 
 dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
 
-  cupertino_ui: any
-  material_ui: any
 flutter:
   plugin:
     platforms:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+  cupertino_ui: any
+  material_ui: any
 flutter:
   plugin:
     platforms:

--- a/test/adaptive_widgets_test.dart
+++ b/test/adaptive_widgets_test.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data' show Uint8List;
 
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:native_adaptive_ui/native_adaptive_ui.dart';
 


### PR DESCRIPTION
…ently

## What and why

<!-- What does this change, and what problem does it solve? -->


This pull request updates the codebase to use the new `cupertino_ui` and `material_ui` packages instead of importing Cupertino and Material components directly from Flutter. This change is reflected in both the main application code and test files, and the new dependencies are added to the relevant `pubspec.yaml` files.



## Design source

<!--
If this changes rendering behavior, cite the HIG/Material rule it follows
or corrects (see doc/design-specs.md), or the device/OS this was verified
against.
-->

## Checklist

- [*] `flutter analyze` passes
- [*] `flutter test` passes
- [*] `dart format --output=none --set-exit-if-changed .` is clean
- [ ] Added/updated a test in `test/adaptive_widgets_test.dart` if this
      changes widget behavior
- [ ] Updated `CHANGELOG.md` if this is a user-visible change
