### PR TITLE
Add go_router support with AdaptiveApp.router integration

### DIFF
--- a/example/lib/router_example.dart
+++ b/example/lib/router_example.dart
@@ -1,0 +1,240 @@
+/// The go_router counterpart to `main.dart`, runnable on its own:
+///
+/// ```sh
+/// flutter run -t lib/router_example.dart
+/// ```
+///
+/// `main.dart` owns its selected tab with `setState`. This one hands the same
+/// job to go_router and changes nothing else — `AdaptiveNavigationScaffold`
+/// documents `selectedIndex` as caller-owned precisely so a router can be that
+/// caller. The three pieces worth copying are marked below:
+///
+/// 1. [AdaptiveApp.router] instead of `AdaptiveApp`.
+/// 2. `StatefulShellRoute.indexedStack` driving the navigation scaffold, with
+///    `detailNavigator: false`.
+/// 3. `adaptivePage` in a `pageBuilder`, and `canPop`/`onBack` on a pushed
+///    [AdaptiveScaffold].
+library;
+
+import 'package:flutter/cupertino.dart' show CupertinoIcons;
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:native_adaptive_ui/native_adaptive_ui.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await NativeAdaptiveUi.ensureInitialized();
+  runApp(const RouterExampleApp());
+}
+
+const _destinations = <AdaptiveDestination>[
+  AdaptiveDestination(
+    label: 'Library',
+    icon: Icon(Icons.library_music),
+    appleIcon: Icon(CupertinoIcons.music_albums),
+    sfSymbol: 'music.note.list',
+  ),
+  AdaptiveDestination(
+    label: 'Search',
+    icon: Icon(Icons.search),
+    appleIcon: Icon(CupertinoIcons.search),
+    sfSymbol: 'magnifyingglass',
+  ),
+  AdaptiveDestination(
+    label: 'Settings',
+    icon: Icon(Icons.settings),
+    appleIcon: Icon(CupertinoIcons.gear),
+    sfSymbol: 'gearshape',
+  ),
+];
+
+class RouterExampleApp extends StatefulWidget {
+  const RouterExampleApp({super.key});
+
+  @override
+  State<RouterExampleApp> createState() => _RouterExampleAppState();
+}
+
+class _RouterExampleAppState extends State<RouterExampleApp> {
+  DesignEra? _eraOverride;
+
+  /// Built once, in a field, rather than inside `build`. A `GoRouter` owns the
+  /// current location, so rebuilding it on every era change would send the app
+  /// back to `/` each time the picker moves.
+  late final GoRouter _router = GoRouter(
+    initialLocation: '/library',
+    routes: [
+      // (2) The shell. `navigationShell.currentIndex` and `goBranch` map
+      // one-to-one onto the scaffold's `selectedIndex` and
+      // `onDestinationSelected` — no adapter, no mirrored state.
+      StatefulShellRoute.indexedStack(
+        builder: (context, state, navigationShell) =>
+            AdaptiveNavigationScaffold(
+          title: 'Router gallery',
+          destinations: _destinations,
+          selectedIndex: navigationShell.currentIndex,
+          onDestinationSelected: navigationShell.goBranch,
+          style: AdaptiveNavigationStyle.sidebarAdaptable,
+          // Required with any outer router. Left at its default (true), the
+          // iPad sidebar layout installs a nested Navigator of its own, which
+          // would swallow every `context.go`/`context.push` below.
+          detailNavigator: false,
+          body: navigationShell,
+        ),
+        branches: [
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: '/library',
+                builder: (context, state) => const _LibraryPage(),
+                routes: [
+                  GoRoute(
+                    path: 'album/:id',
+                    // (3) adaptivePage, not a bare MaterialPage: this is what
+                    // keeps the iOS edge-swipe back gesture on Apple eras.
+                    pageBuilder: (context, state) => adaptivePage(
+                      context: context,
+                      title: 'Library',
+                      child: _AlbumPage(id: state.pathParameters['id']!),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: '/search',
+                builder: (context, state) => const _SearchPage(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: '/settings',
+                builder: (context, state) => _SettingsPage(
+                  era: _eraOverride,
+                  onEraChanged: (era) => setState(() => _eraOverride = era),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    // (1) The only change from `main.dart`'s AdaptiveApp: a routerConfig in
+    // place of `home`. go_router is not a dependency of native_adaptive_ui —
+    // `GoRouter implements RouterConfig<RouteMatchList>`, and that is the
+    // entire integration.
+    return AdaptiveApp.router(
+      title: 'native_adaptive_ui + go_router',
+      eraOverride: _eraOverride,
+      routerConfig: _router,
+    );
+  }
+}
+
+class _LibraryPage extends StatelessWidget {
+  const _LibraryPage();
+
+  @override
+  Widget build(BuildContext context) {
+    return AdaptiveScaffold(
+      title: 'Library',
+      body: AdaptiveListSection(
+        header: 'Albums',
+        children: [
+          for (var i = 1; i <= 3; i++)
+            AdaptiveListTile(
+              title: 'Album $i',
+              subtitle: 'Tap to push a detail route',
+              onTap: () => context.go('/library/album/$i'),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AlbumPage extends StatelessWidget {
+  const _AlbumPage({required this.id});
+
+  final String id;
+
+  @override
+  Widget build(BuildContext context) {
+    return AdaptiveScaffold(
+      title: 'Album $id',
+      // (3) The back button asks the router, not the enclosing Navigator.
+      // Inside a shell branch those two disagree often enough that guessing is
+      // not worth it — `GoRouter.of(context).canPop()` is the real answer.
+      canPop: context.canPop(),
+      onBack: context.pop,
+      body: Center(child: Text('Album $id')),
+    );
+  }
+}
+
+class _SearchPage extends StatelessWidget {
+  const _SearchPage();
+
+  @override
+  Widget build(BuildContext context) {
+    return const AdaptiveScaffold(
+      title: 'Search',
+      body: Padding(
+        padding: EdgeInsets.all(16),
+        child: AdaptiveSearchField(placeholder: 'Search'),
+      ),
+    );
+  }
+}
+
+class _SettingsPage extends StatelessWidget {
+  const _SettingsPage({required this.era, required this.onEraChanged});
+
+  final DesignEra? era;
+  final ValueChanged<DesignEra?> onEraChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return AdaptiveScaffold(
+      title: 'Settings',
+      // A section is a Column, not a scroller, and the era list is longer than
+      // a phone screen — same reason every page in main.dart wraps one in a
+      // ListView.
+      body: Builder(
+        builder: (context) => ListView(
+          padding: context.adaptiveScrollPadding(),
+          children: [
+            AdaptiveListSection(
+              header: 'Preview era',
+              // Switching era rebuilds AdaptiveApp.router — swapping
+              // CupertinoApp for MaterialApp — without rebuilding the router,
+              // so the app stays on /settings across the change.
+              children: [
+                AdaptiveListTile(
+                  title: 'Automatic',
+                  trailing: era == null ? const Icon(Icons.check) : null,
+                  onTap: () => onEraChanged(null),
+                ),
+                for (final option in DesignEra.values)
+                  AdaptiveListTile(
+                    title: option.name,
+                    trailing: era == option ? const Icon(Icons.check) : null,
+                    onTap: () => onEraChanged(option),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   flutter:
     sdk: flutter
+  go_router: ^18.0.0
   native_adaptive_ui:
     path: ../
 

--- a/example/test/router_example_test.dart
+++ b/example/test/router_example_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/cupertino.dart' show CupertinoApp;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_adaptive_ui/native_adaptive_ui.dart';
+
+import 'package:native_adaptive_ui_example/router_example.dart';
+
+void main() {
+  setUp(() {
+    // router_example.dart calls NativeAdaptiveUi.ensureInitialized() from
+    // main(), which a widget test never runs — same reason widget_test.dart
+    // injects the era by hand.
+    NativeAdaptiveUi.debugSetPlatform(
+      PlatformInfo.fake(era: DesignEra.material3),
+    );
+    addTearDown(() => NativeAdaptiveUi.debugSetPlatform(null));
+  });
+
+  testWidgets('the shell route drives the navigation scaffold', (tester) async {
+    await tester.pumpWidget(const RouterExampleApp());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Library'), findsWidgets);
+
+    // goBranch, reached through onDestinationSelected.
+    await tester.tap(find.byIcon(Icons.settings));
+    await tester.pumpAndSettle();
+    expect(find.text('Preview era'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.library_music));
+    await tester.pumpAndSettle();
+    expect(find.text('Albums'), findsOneWidget);
+  });
+
+  testWidgets('a pushed route pops through onBack, not the Navigator', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const RouterExampleApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Album 2'));
+    await tester.pumpAndSettle();
+    expect(find.text('Album 2'), findsWidgets);
+
+    // canPop/onBack came from the router; tapping the back button has to
+    // return to the branch root rather than throwing or doing nothing.
+    expect(find.byType(BackButton), findsOneWidget);
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+    expect(find.text('Albums'), findsOneWidget);
+  });
+
+  testWidgets('changing era swaps the app widget without losing location', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const RouterExampleApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.settings));
+    await tester.pumpAndSettle();
+    expect(find.byType(MaterialApp), findsOneWidget);
+
+    await tester.tap(find.text('iosLiquidGlass'));
+    await tester.pumpAndSettle();
+
+    // AdaptiveApp.router rebuilt as a CupertinoApp, and the router kept the
+    // current branch — the settings list is still on screen.
+    expect(find.byType(CupertinoApp), findsOneWidget);
+    expect(find.byType(MaterialApp), findsNothing);
+    expect(find.text('Preview era'), findsOneWidget);
+  });
+}

--- a/lib/native_adaptive_ui.dart
+++ b/lib/native_adaptive_ui.dart
@@ -63,7 +63,8 @@ export 'src/widgets/adaptive_navigation.dart'
         adaptiveTabBarKey;
 export 'src/widgets/adaptive_progress_indicator.dart'
     show AdaptiveProgressIndicator;
-export 'src/widgets/adaptive_route.dart' show adaptivePageRoute, pushAdaptive;
+export 'src/widgets/adaptive_route.dart'
+    show adaptivePage, adaptivePageRoute, pushAdaptive;
 export 'src/widgets/adaptive_scaffold.dart' show AdaptiveScaffold;
 export 'src/widgets/adaptive_search_field.dart'
     show AdaptiveSearchField, AdaptiveSearchToolbarButton;

--- a/lib/src/widgets/adaptive_app.dart
+++ b/lib/src/widgets/adaptive_app.dart
@@ -12,6 +12,8 @@ import '../design_systems/design_imports.dart';
 /// `Tooltip` into an iOS build and it throws *"No Material widget found"*.
 /// [AdaptiveApp] inserts a transparent `Material` above the navigator on Apple
 /// eras, so mixing the two systems is safe without changing how anything looks.
+///
+/// For go_router — or any other Router 2.0 package — use [AdaptiveApp.router].
 class AdaptiveApp extends StatelessWidget {
   const AdaptiveApp({
     super.key,
@@ -32,7 +34,69 @@ class AdaptiveApp extends StatelessWidget {
     this.eraOverride,
     this.policy,
     this.builder,
-  });
+  })  : routerConfig = null,
+        routerDelegate = null,
+        routeInformationParser = null,
+        routeInformationProvider = null,
+        backButtonDispatcher = null,
+        _useRouter = false;
+
+  /// The Router 2.0 counterpart, for go_router and friends.
+  ///
+  /// This package does not depend on go_router, and does not need to:
+  /// `GoRouter implements RouterConfig<RouteMatchList>`, so a router drops
+  /// straight into [routerConfig] — as does a Beamer or auto_route delegate,
+  /// or a hand-rolled [RouterDelegate].
+  ///
+  /// ```dart
+  /// AdaptiveApp.router(
+  ///   routerConfig: GoRouter(routes: [...]),
+  /// )
+  /// ```
+  ///
+  /// Everything the default constructor does still applies — the era-based
+  /// Cupertino/Material split, the transparent `Material`, and the
+  /// `MaterialLocalizations` delegate — because `WidgetsApp` applies its
+  /// `builder` around the `Router`, which leaves the [AdaptiveScope] above the
+  /// router's navigator. Route bodies and `pageBuilder` callbacks alike resolve
+  /// it, so `adaptivePage` works inside a `GoRoute`.
+  ///
+  /// The era itself is resolved once, in [build], from `NativeAdaptiveUi.era`.
+  /// Changing [eraOverride] therefore rebuilds the app and swaps `CupertinoApp`
+  /// for `MaterialApp`, but never rebuilds the router config or disturbs the
+  /// current location.
+  const AdaptiveApp.router({
+    super.key,
+    this.routerConfig,
+    this.routerDelegate,
+    this.routeInformationParser,
+    this.routeInformationProvider,
+    this.backButtonDispatcher,
+    this.title = '',
+    this.materialTheme,
+    this.materialDarkTheme,
+    this.cupertinoTheme,
+    this.themeMode = ThemeMode.system,
+    this.debugShowCheckedModeBanner = true,
+    this.locale,
+    this.localizationsDelegates,
+    this.supportedLocales = const <Locale>[Locale('en', 'US')],
+    this.eraOverride,
+    this.policy,
+    this.builder,
+  })  : assert(
+          routerDelegate != null || routerConfig != null,
+          'Either routerDelegate or routerConfig must be provided.',
+        ),
+        home = null,
+        routes = const <String, WidgetBuilder>{},
+        initialRoute = null,
+        onGenerateRoute = null,
+        // The router owns the navigator, so there is no key to hand it, and
+        // MaterialApp.router takes no navigatorKey either. Reach the navigator
+        // through the router instead — GoRouter takes its own navigatorKey.
+        navigatorKey = null,
+        _useRouter = true;
 
   final Widget? home;
   final Map<String, WidgetBuilder> routes;
@@ -40,6 +104,15 @@ class AdaptiveApp extends StatelessWidget {
   final RouteFactory? onGenerateRoute;
   final GlobalKey<NavigatorState>? navigatorKey;
   final String title;
+
+  /// The whole routing configuration in one object. A `GoRouter` goes here.
+  final RouterConfig<Object>? routerConfig;
+
+  /// Used instead of [routerConfig] when the pieces are supplied separately.
+  final RouterDelegate<Object>? routerDelegate;
+  final RouteInformationParser<Object>? routeInformationParser;
+  final RouteInformationProvider? routeInformationProvider;
+  final BackButtonDispatcher? backButtonDispatcher;
 
   final ThemeData? materialTheme;
   final ThemeData? materialDarkTheme;
@@ -59,6 +132,10 @@ class AdaptiveApp extends StatelessWidget {
 
   /// Wraps every route, after the adaptive scope is installed.
   final TransitionBuilder? builder;
+
+  /// Set by [AdaptiveApp.router]. Selects the `.router` flavour of whichever
+  /// app widget the era picks.
+  final bool _useRouter;
 
   @override
   Widget build(BuildContext context) {
@@ -100,6 +177,34 @@ class AdaptiveApp extends StatelessWidget {
     }
 
     if (era.isApple) {
+      // Material widgets used as fallbacks inside a Cupertino app assert on
+      // MaterialLocalizations, which CupertinoApp does not install: the iPad
+      // popover menu, Tooltip and ListTile all throw without it. Same class of
+      // problem as the missing Material ancestor above, and it belongs in the
+      // same place — on the router path too, which is just as capable of
+      // showing a ListTile.
+      final appleDelegates = <LocalizationsDelegate<dynamic>>[
+        ...?localizationsDelegates,
+        DefaultMaterialLocalizations.delegate,
+      ];
+
+      if (_useRouter) {
+        return CupertinoApp.router(
+          routerConfig: routerConfig,
+          routerDelegate: routerDelegate,
+          routeInformationParser: routeInformationParser,
+          routeInformationProvider: routeInformationProvider,
+          backButtonDispatcher: backButtonDispatcher,
+          title: title,
+          theme: cupertinoTheme,
+          debugShowCheckedModeBanner: debugShowCheckedModeBanner,
+          locale: locale,
+          localizationsDelegates: appleDelegates,
+          supportedLocales: supportedLocales,
+          builder: wrap,
+        );
+      }
+
       return CupertinoApp(
         navigatorKey: navigatorKey,
         title: title,
@@ -110,15 +215,26 @@ class AdaptiveApp extends StatelessWidget {
         theme: cupertinoTheme,
         debugShowCheckedModeBanner: debugShowCheckedModeBanner,
         locale: locale,
-        localizationsDelegates: <LocalizationsDelegate<dynamic>>[
-          ...?localizationsDelegates,
-          // Material widgets used as fallbacks inside a Cupertino app assert on
-          // MaterialLocalizations, which CupertinoApp does not install: the
-          // iPad popover menu, Tooltip and ListTile all throw without it. Same
-          // class of problem as the missing Material ancestor above, and it
-          // belongs in the same place.
-          DefaultMaterialLocalizations.delegate,
-        ],
+        localizationsDelegates: appleDelegates,
+        supportedLocales: supportedLocales,
+        builder: wrap,
+      );
+    }
+
+    if (_useRouter) {
+      return MaterialApp.router(
+        routerConfig: routerConfig,
+        routerDelegate: routerDelegate,
+        routeInformationParser: routeInformationParser,
+        routeInformationProvider: routeInformationProvider,
+        backButtonDispatcher: backButtonDispatcher,
+        title: title,
+        theme: materialTheme,
+        darkTheme: materialDarkTheme,
+        themeMode: themeMode,
+        debugShowCheckedModeBanner: debugShowCheckedModeBanner,
+        locale: locale,
+        localizationsDelegates: localizationsDelegates,
         supportedLocales: supportedLocales,
         builder: wrap,
       );

--- a/lib/src/widgets/adaptive_route.dart
+++ b/lib/src/widgets/adaptive_route.dart
@@ -39,6 +39,64 @@ PageRoute<T> adaptivePageRoute<T>({
   );
 }
 
+/// The declarative counterpart to [adaptivePageRoute], for Router 2.0.
+///
+/// `GoRoute.pageBuilder` — and every other `Page`-based API — wants a [Page],
+/// not a [Route], so [adaptivePageRoute] cannot be used there. This returns the
+/// same platform split one level up: a `CupertinoPage` on Apple eras, including
+/// the interactive edge-swipe back gesture, and a `MaterialPage` elsewhere.
+///
+/// ```dart
+/// GoRoute(
+///   path: 'detail',
+///   pageBuilder: (context, state) => adaptivePage(
+///     context: context,
+///     child: const DetailScreen(),
+///   ),
+/// )
+/// ```
+///
+/// The `context` handed to a `pageBuilder` sits below [AdaptiveApp.router]'s
+/// scope — `WidgetsApp` wraps the `Router` in its `builder` — so the era
+/// resolves here exactly as it does inside a route body.
+///
+/// [title] is Cupertino-only: it supplies the text that the *next* screen's
+/// back button shows, and `MaterialPage` has no equivalent.
+Page<T> adaptivePage<T>({
+  required BuildContext context,
+  required Widget child,
+  LocalKey? key,
+  String? name,
+  Object? arguments,
+  String? restorationId,
+  String? title,
+  bool fullscreenDialog = false,
+  bool maintainState = true,
+}) {
+  final era = AdaptiveScope.of(context).era;
+  if (era.isApple) {
+    return CupertinoPage<T>(
+      child: child,
+      key: key,
+      name: name,
+      arguments: arguments,
+      restorationId: restorationId,
+      title: title,
+      fullscreenDialog: fullscreenDialog,
+      maintainState: maintainState,
+    );
+  }
+  return MaterialPage<T>(
+    child: child,
+    key: key,
+    name: name,
+    arguments: arguments,
+    restorationId: restorationId,
+    fullscreenDialog: fullscreenDialog,
+    maintainState: maintainState,
+  );
+}
+
 /// Pushes [page] with the platform's own transition.
 ///
 /// ```dart

--- a/lib/src/widgets/adaptive_scaffold.dart
+++ b/lib/src/widgets/adaptive_scaffold.dart
@@ -49,6 +49,8 @@ class AdaptiveScaffold extends StatelessWidget {
     this.actionSfSymbols,
     this.onLeadingPressed,
     this.onActionPressed,
+    this.canPop,
+    this.onBack,
   });
 
   final Widget body;
@@ -77,6 +79,29 @@ class AdaptiveScaffold extends StatelessWidget {
   /// Fires with the tapped button's index into [actionSfSymbols]. Unused
   /// otherwise.
   final ValueChanged<int>? onActionPressed;
+
+  /// Whether a back affordance is shown. Defaults to `Navigator.canPop`.
+  ///
+  /// That default is right whenever the enclosing `Navigator` is the whole
+  /// story, and wrong as soon as a router splits navigation across more than
+  /// one — a go_router screen pushed on the *root* navigator from inside a
+  /// shell can pop, but `Navigator.canPop` asked from the shell says it cannot,
+  /// and a branch root that `context.pop()` would return to another branch
+  /// reports the reverse. Pass the router's own answer here in that case:
+  ///
+  /// ```dart
+  /// AdaptiveScaffold(
+  ///   title: 'Detail',
+  ///   canPop: context.canPop(),
+  ///   onBack: context.pop,
+  ///   body: ...,
+  /// )
+  /// ```
+  final bool? canPop;
+
+  /// What the back affordance does. Defaults to
+  /// `Navigator.of(context).maybePop()`. See [canPop].
+  final VoidCallback? onBack;
 
   /// The toolbar's center region. HIG: "customisable on macOS/iPadOS,
   /// collapses into a system overflow menu" — folded into the trailing group
@@ -201,14 +226,15 @@ class AdaptiveScaffold extends StatelessWidget {
       // that needs nothing extra here. The native bar has no such thing to
       // fall back on: it is a bare UINavigationBar with no UINavigationController
       // above it, so nothing supplies a back button unless this does.
-      final canPop = Navigator.canPop(context);
-      final autoBack = leadingSfSymbol == null && leading == null && canPop;
+      final effectiveCanPop = canPop ?? Navigator.canPop(context);
+      final autoBack =
+          leadingSfSymbol == null && leading == null && effectiveCanPop;
       final effectiveLeadingSfSymbol =
           leadingSfSymbol ?? (autoBack ? 'chevron.backward' : null);
       final effectiveOnLeadingPressed = leadingSfSymbol != null
           ? onLeadingPressed
           : (autoBack
-              ? () => Navigator.of(context).maybePop()
+              ? (onBack ?? () => Navigator.of(context).maybePop())
               : onLeadingPressed);
 
       return CupertinoPageScaffold(
@@ -225,16 +251,15 @@ class AdaptiveScaffold extends StatelessWidget {
                   )
                 : CupertinoNavigationBar(
                     middle: title == null ? null : Text(title!),
-                    // CupertinoNavigationBar already auto-generates a plain
-                    // chevron+"Back" leading from Navigator.canPop when this
-                    // is null — the correct look for iosClassic/macosClassic.
-                    // On a glass era that default predates Liquid Glass, so
-                    // it's replaced with the same rounded glass button the
-                    // native bar gets automatically from UIKit.
-                    leading: leading ??
-                        (leadingSfSymbol == null && canPop && tokens.hasGlass
-                            ? _GlassBackButton(tokens: tokens)
-                            : null),
+                    // CupertinoNavigationBar auto-generates a plain
+                    // chevron+"Back" leading from Navigator.canPop when
+                    // `leading` is null — the correct look for
+                    // iosClassic/macosClassic, and the reason this is only
+                    // overridden below. Gating it on [effectiveCanPop] is what
+                    // lets `canPop: false` suppress a chevron the enclosing
+                    // navigator would otherwise imply.
+                    automaticallyImplyLeading: effectiveCanPop,
+                    leading: _appleLeading(context, tokens, effectiveCanPop),
                     trailing: _appleTrailing(context, tokens),
                   ),
         child: content,
@@ -246,7 +271,15 @@ class AdaptiveScaffold extends StatelessWidget {
       appBar: _hasBar
           ? AppBar(
               title: title == null ? null : Text(title!),
-              leading: leading,
+              // AppBar makes the same judgement CupertinoNavigationBar does,
+              // from ModalRoute rather than the router, so the overrides have
+              // to reach it too — otherwise the two eras disagree about
+              // whether this screen has a back button at all.
+              automaticallyImplyLeading: canPop ?? true,
+              leading: leading ??
+                  (onBack != null && (canPop ?? Navigator.canPop(context))
+                      ? BackButton(onPressed: onBack)
+                      : null),
               actions: [
                 ...centerActions,
                 ...actions,
@@ -271,6 +304,30 @@ class AdaptiveScaffold extends StatelessWidget {
       '[native_adaptive_ui] AdaptiveScaffold title "$title" is longer than '
       "HIG's guidance of under 15 characters for a toolbar title.",
     );
+  }
+
+  /// The leading widget for `CupertinoNavigationBar`.
+  ///
+  /// Returning null hands the decision back to the bar's own
+  /// `automaticallyImplyLeading`, which is the right answer on a classic Apple
+  /// era with no overrides. Two cases have to be built by hand instead: a glass
+  /// era, whose default chevron+"Back" predates Liquid Glass, and a caller who
+  /// supplied [canPop]/[onBack] — the bar would consult the enclosing navigator
+  /// rather than the router, and pop the wrong thing.
+  Widget? _appleLeading(
+    BuildContext context,
+    AdaptiveTokens tokens,
+    bool effectiveCanPop,
+  ) {
+    if (leading != null) return leading;
+    if (leadingSfSymbol != null || !effectiveCanPop) return null;
+    if (tokens.hasGlass) {
+      return _GlassBackButton(tokens: tokens, onPressed: onBack);
+    }
+    if (canPop != null || onBack != null) {
+      return CupertinoNavigationBarBackButton(onPressed: onBack);
+    }
+    return null;
   }
 
   /// Cupertino navigation bars take exactly one trailing widget, so
@@ -384,9 +441,13 @@ class _OverflowButton extends StatelessWidget {
 /// `UIBarButtonItem` to lean on: `CupertinoNavigationBar`'s own default
 /// leading is a plain chevron-and-label predating Liquid Glass entirely.
 class _GlassBackButton extends StatelessWidget {
-  const _GlassBackButton({required this.tokens});
+  const _GlassBackButton({required this.tokens, this.onPressed});
 
   final AdaptiveTokens tokens;
+
+  /// Defaults to `maybePop` on the enclosing navigator. See
+  /// [AdaptiveScaffold.onBack].
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -399,7 +460,7 @@ class _GlassBackButton extends StatelessWidget {
         child: CupertinoButton(
           padding: EdgeInsets.zero,
           minimumSize: const Size(size, size),
-          onPressed: () => Navigator.of(context).maybePop(),
+          onPressed: onPressed ?? () => Navigator.of(context).maybePop(),
           child: GlassSurface(
             tokens: tokens,
             interactive: true,

--- a/lib/src/widgets/adaptive_scaffold.dart
+++ b/lib/src/widgets/adaptive_scaffold.dart
@@ -271,14 +271,17 @@ class AdaptiveScaffold extends StatelessWidget {
       appBar: _hasBar
           ? AppBar(
               title: title == null ? null : Text(title!),
-              // AppBar makes the same judgement CupertinoNavigationBar does,
-              // from ModalRoute rather than the router, so the overrides have
-              // to reach it too — otherwise the two eras disagree about
-              // whether this screen has a back button at all.
-              automaticallyImplyLeading: canPop ?? true,
+              // When canPop/onBack are supplied (e.g. by a router), override the
+              // default ModalRoute/Navigator heuristics and render a back
+              // affordance explicitly.
+              automaticallyImplyLeading: canPop == null && onBack == null,
               leading: leading ??
-                  (onBack != null && (canPop ?? Navigator.canPop(context))
-                      ? BackButton(onPressed: onBack)
+                  ((canPop != null || onBack != null) &&
+                          (canPop ?? Navigator.canPop(context))
+                      ? BackButton(
+                          onPressed:
+                              onBack ?? () => Navigator.of(context).maybePop(),
+                        )
                       : null),
               actions: [
                 ...centerActions,

--- a/test/adaptive_widgets_test.dart
+++ b/test/adaptive_widgets_test.dart
@@ -38,6 +38,58 @@ Future<void> pumpEra(
   );
 }
 
+/// Like [pumpEra], but pumps [app] itself rather than wrapping a child in a
+/// plain `MaterialApp`. [AdaptiveApp] installs its own [AdaptiveScope], so
+/// wrapping it in another one would test the wrapper instead of the widget.
+Future<void> pumpApp(
+  WidgetTester tester,
+  DesignEra era,
+  Widget app, {
+  double width = 390,
+  double height = 844,
+}) async {
+  NativeAdaptiveUi.debugSetPlatform(PlatformInfo.fake(era: era));
+  addTearDown(() => NativeAdaptiveUi.debugSetPlatform(null));
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = Size(width, height);
+  addTearDown(tester.view.reset);
+  await tester.pumpWidget(app);
+}
+
+/// A minimal hand-rolled Router 2.0 config.
+///
+/// The point of `AdaptiveApp.router` is that it takes a `RouterConfig` and so
+/// needs no router package; testing it with one would undercut that. `GoRouter`
+/// reaches `routerConfig` through exactly this interface.
+RouterConfig<Object> _testRouterConfig(List<Widget> Function() pages) {
+  return RouterConfig<Object>(
+    routerDelegate: _TestRouterDelegate(pages),
+  );
+}
+
+class _TestRouterDelegate extends RouterDelegate<Object>
+    with ChangeNotifier, PopNavigatorRouterDelegateMixin<Object> {
+  _TestRouterDelegate(this._pages);
+
+  final List<Widget> Function() _pages;
+
+  @override
+  final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+
+  @override
+  Widget build(BuildContext context) => Navigator(
+        key: navigatorKey,
+        pages: <Page<Object?>>[
+          for (final page in _pages())
+            MaterialPage<void>(key: ValueKey<Widget>(page), child: page),
+        ],
+        onDidRemovePage: (_) {},
+      );
+
+  @override
+  Future<void> setNewRoutePath(Object configuration) async {}
+}
+
 void main() {
   tearDown(() => NativeAdaptiveUi.debugSetPlatform(null));
 
@@ -887,6 +939,253 @@ void main() {
         AdaptiveSlider(value: 0.5, onChanged: (_) {}, vertical: true),
       );
       expect(find.byType(RotatedBox), findsOneWidget);
+    });
+  });
+
+  group('AdaptiveApp.router', () {
+    testWidgets('builds a CupertinoApp on an Apple era', (tester) async {
+      await pumpApp(
+        tester,
+        DesignEra.iosLiquidGlass,
+        AdaptiveApp.router(
+          routerConfig: _testRouterConfig(
+            () => const <Widget>[AdaptiveScaffold(title: 'Home', body: SizedBox())],
+          ),
+        ),
+      );
+      expect(find.byType(CupertinoApp), findsOneWidget);
+      expect(find.byType(MaterialApp), findsNothing);
+      expect(find.text('Home'), findsOneWidget);
+    });
+
+    testWidgets('builds a MaterialApp on a Material era', (tester) async {
+      await pumpApp(
+        tester,
+        DesignEra.material3,
+        AdaptiveApp.router(
+          routerConfig: _testRouterConfig(
+            () => const <Widget>[AdaptiveScaffold(title: 'Home', body: SizedBox())],
+          ),
+        ),
+      );
+      expect(find.byType(MaterialApp), findsOneWidget);
+      expect(find.byType(CupertinoApp), findsNothing);
+    });
+
+    // The whole reason AdaptiveApp exists. A CupertinoApp supplies neither a
+    // Material ancestor nor MaterialLocalizations, so a ListTile inside one
+    // throws twice over — and the router path is just as capable of showing a
+    // ListTile as the navigator path is.
+    testWidgets('keeps the Material and localizations shims on Apple eras', (
+      tester,
+    ) async {
+      await pumpApp(
+        tester,
+        DesignEra.iosLiquidGlass,
+        AdaptiveApp.router(
+          routerConfig: _testRouterConfig(
+            () => const <Widget>[
+              AdaptiveScaffold(
+                title: 'Home',
+                body: ListTile(title: Text('Profile')),
+              ),
+            ],
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+      expect(find.text('Profile'), findsOneWidget);
+      final context = tester.element(find.text('Profile'));
+      expect(context.findAncestorWidgetOfExactType<Material>(), isNotNull);
+      expect(Localizations.of<MaterialLocalizations>(
+        context,
+        MaterialLocalizations,
+      ), isNotNull);
+    });
+
+    testWidgets('installs an AdaptiveScope above the router', (tester) async {
+      late DesignEra seen;
+      await pumpApp(
+        tester,
+        DesignEra.material3,
+        AdaptiveApp.router(
+          eraOverride: DesignEra.iosLiquidGlass,
+          routerConfig: _testRouterConfig(
+            () => <Widget>[
+              Builder(
+                builder: (context) {
+                  seen = AdaptiveScope.of(context).era;
+                  return const SizedBox();
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+      // eraOverride wins over the fake platform, and reaches route bodies —
+      // which is what makes adaptivePage resolvable inside a pageBuilder.
+      expect(seen, DesignEra.iosLiquidGlass);
+      expect(find.byType(CupertinoApp), findsOneWidget);
+    });
+  });
+
+  group('adaptivePage', () {
+    testWidgets('returns a CupertinoPage on Apple eras', (tester) async {
+      late Page<void> page;
+      await pumpEra(
+        tester,
+        DesignEra.iosLiquidGlass,
+        Builder(
+          builder: (context) {
+            page = adaptivePage<void>(
+              context: context,
+              child: const SizedBox(),
+              title: 'Detail',
+            );
+            return const SizedBox();
+          },
+        ),
+      );
+      expect(page, isA<CupertinoPage<void>>());
+      expect((page as CupertinoPage<void>).title, 'Detail');
+    });
+
+    testWidgets('returns a MaterialPage on Material eras', (tester) async {
+      late Page<void> page;
+      await pumpEra(
+        tester,
+        DesignEra.material3,
+        Builder(
+          builder: (context) {
+            page = adaptivePage<void>(context: context, child: const SizedBox());
+            return const SizedBox();
+          },
+        ),
+      );
+      expect(page, isA<MaterialPage<void>>());
+    });
+  });
+
+  group('AdaptiveScaffold router back button', () {
+    testWidgets('canPop: false suppresses the back button on a pushed route', (
+      tester,
+    ) async {
+      await pumpEra(
+        tester,
+        DesignEra.iosLiquidGlass,
+        Builder(
+          builder: (context) => AdaptiveButton(
+            onPressed: () => Navigator.of(context).push(
+              CupertinoPageRoute<void>(
+                builder: (_) => const AdaptiveScaffold(
+                  title: 'Detail',
+                  canPop: false,
+                  body: SizedBox(),
+                ),
+              ),
+            ),
+            child: const Text('Push'),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Push'));
+      await tester.pumpAndSettle();
+      // Navigator.canPop is true here; the override is what wins.
+      expect(find.byIcon(CupertinoIcons.chevron_back), findsNothing);
+    });
+
+    testWidgets('canPop: true shows a back button on a root route', (
+      tester,
+    ) async {
+      var popped = 0;
+      await pumpEra(
+        tester,
+        DesignEra.iosLiquidGlass,
+        AdaptiveScaffold(
+          title: 'Branch root',
+          canPop: true,
+          onBack: () => popped++,
+          body: const SizedBox(),
+        ),
+      );
+      // Nothing to pop on this navigator — the router says otherwise.
+      expect(find.byIcon(CupertinoIcons.chevron_back), findsOneWidget);
+      await tester.tap(find.byIcon(CupertinoIcons.chevron_back));
+      await tester.pumpAndSettle();
+      expect(popped, 1);
+    });
+
+    testWidgets('onBack replaces maybePop on a pushed route', (tester) async {
+      var popped = 0;
+      await pumpEra(
+        tester,
+        DesignEra.iosLiquidGlass,
+        Builder(
+          builder: (context) => AdaptiveButton(
+            onPressed: () => Navigator.of(context).push(
+              CupertinoPageRoute<void>(
+                builder: (_) => AdaptiveScaffold(
+                  title: 'Detail',
+                  onBack: () => popped++,
+                  body: const SizedBox(),
+                ),
+              ),
+            ),
+            child: const Text('Push'),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Push'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(CupertinoIcons.chevron_back));
+      await tester.pumpAndSettle();
+      expect(popped, 1);
+      // onBack fired instead of popping, so the route is still up.
+      expect(find.text('Detail'), findsOneWidget);
+    });
+
+    testWidgets('reaches the Material AppBar too', (tester) async {
+      var popped = 0;
+      await pumpEra(
+        tester,
+        DesignEra.material3,
+        AdaptiveScaffold(
+          title: 'Branch root',
+          canPop: true,
+          onBack: () => popped++,
+          body: const SizedBox(),
+        ),
+      );
+      expect(find.byType(BackButton), findsOneWidget);
+      await tester.tap(find.byType(BackButton));
+      await tester.pumpAndSettle();
+      expect(popped, 1);
+    });
+
+    testWidgets('canPop: false suppresses the Material back button', (
+      tester,
+    ) async {
+      await pumpEra(
+        tester,
+        DesignEra.material3,
+        Builder(
+          builder: (context) => AdaptiveButton(
+            onPressed: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => const AdaptiveScaffold(
+                  title: 'Detail',
+                  canPop: false,
+                  body: SizedBox(),
+                ),
+              ),
+            ),
+            child: const Text('Push'),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Push'));
+      await tester.pumpAndSettle();
+      expect(find.byType(BackButton), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## What and why

<!-- What does this change, and what problem does it solve? -->

This pull request adds comprehensive support for Router 2.0 navigation (such as `go_router`) to the `native_adaptive_ui` package, enabling seamless integration with modern routing solutions in Flutter. The main changes include the introduction of `AdaptiveApp.router`, a new `adaptivePage` helper for declarative page APIs, and enhancements to `AdaptiveScaffold` for better back navigation handling. An example app and tests demonstrate the new capabilities.

**Router 2.0 integration:**
- Added `AdaptiveApp.router`, a constructor that supports `RouterConfig`-based navigation (e.g., `go_router`), and ensures that era-based theming and adaptive features work seamlessly with Router 2.0. This includes proper Cupertino/Material split and localization handling. 
- Added `adaptivePage`, a declarative counterpart to `adaptivePageRoute`, for use in Router 2.0 `pageBuilder` APIs, returning a platform-appropriate 

**AdaptiveScaffold navigation improvements:**
- Added `canPop` and `onBack` parameters to `AdaptiveScaffold`, allowing the caller (such as a router) to control the display and behavior of the back affordance, ensuring correct navigation semantics when used with nested or shell routes.

**Example and test coverage:**
- Added `example/lib/router_example.dart`, a runnable example demonstrating integration with `go_router`, including shell routes and adaptive navigation.
- Added `example/test/router_example_test.dart`, providing widget tests to verify navigation, back affordance behavior, and era switching with Router 2.0.
- Updated `example/pubspec.yaml` to include `go_router` as a dependency.

**Documentation and exports:**
- Updated documentation throughout to clarify usage with Router 2.0 and the relationship between adaptive widgets and routing.
- Exported `adaptivePage` from the package API.

## Design source

<!--
If this changes rendering behavior, cite the HIG/Material rule it follows
or corrects (see doc/design-specs.md), or the device/OS this was verified
against.
-->

## Checklist

- [*] `flutter analyze` passes
- [*] `flutter test` passes
- [*] `dart format --output=none --set-exit-if-changed .` is clean
- [*] Added/updated a test in `test/adaptive_widgets_test.dart` if this
      changes widget behavior
- [ ] Updated `CHANGELOG.md` if this is a user-visible change
